### PR TITLE
Fix constant 'nonce' issue

### DIFF
--- a/smugpy/__init__.py
+++ b/smugpy/__init__.py
@@ -218,7 +218,9 @@ class SmugMug(object):
             "&Access=" + access + "&Permissions=" + perm
 
     def _get_oauth_resource_request_parameters(self, url, parameters={}, method="GET",
-        timestamp=int(time.time()), nonce=binascii.b2a_hex(uuid.uuid4().bytes)):
+        timestamp=int(time.time()), nonce=None):
+        if nonce is None:
+            nonce = binascii.b2a_hex(uuid.uuid4().bytes)
         """Returns the OAuth parameters as a dict for the given resource request."""
         base_args = dict(
             oauth_consumer_key=self.api_key,


### PR DESCRIPTION
A 'nonce' value can only be used once. Smugmug's servers track which nonce values you've sent and sends a `33 - invalid/used nonce` error when it detects a repeat.

This commit fixes the fact that the nonce value was getting computed _only once_ (upon evaluation of the `def _get_oauth_resource_request_parameters(...)`.
