### PR TITLE
Expand example-oauth.py 

### DIFF
--- a/examples/example-oauth.py
+++ b/examples/example-oauth.py
@@ -11,15 +11,88 @@ else:
     get_input = input
 
 API_KEY = "XXXXXXXXXXXXXXXXXXXXXXXXX"
-OAUTH_SECRET = "YYYYYYYYYYYYYYYYYYYYYYY"
+OAUTH_SECRET = "YYYYYYYYYYYYYYYYYYYYYYY" # From SmugMug Settings -> Discovery -> API Keys
+APP_NAME="TestApp"
 
-smugmug = SmugMug(api_key=API_KEY, oauth_secret=OAUTH_SECRET, app_name="TestApp")
+# Request a "request token" from the smugmug servers for the given permissions.
+#
+# Return a pair (url, requestToken) that can be used to authorize this app to
+# access the account of whomever logs in at the URL.
+def smugmugOauthRequestToken(access="Public", perm="Read"):
+    smugmug = SmugMug(api_key=API_KEY, oauth_secret=OAUTH_SECRET, app_name=APP_NAME)
 
-#Oauth handshake
-smugmug.auth_getRequestToken()
-get_input("Authorize app at %s\n\nPress Enter when complete.\n" % (smugmug.authorize()))   
-smugmug.auth_getAccessToken()
+    # Get a token that is short-lived (probably about 5 minutes) and can be used
+    # only to setup authorization at SmugMug
+    response = smugmug.auth_getRequestToken()
 
-albums = smugmug.albums_get(NickName="williams") # Moon River Photography, thanks Andy!
+    # Get the URL that the user must visit to authorize this app (implicilty includes the request token in the URL)
+    url = smugmug.authorize(access=access, perm=perm)
+
+    return url, response['Auth'] # (should contain a 'Token')
+
+# "Visit" the URL (well, print the instructions the user should use to visit
+# the URL).  Once this is done the request token can be used to log in to
+# that user's account and get an "access token" for this app to use that
+# account.
+#
+# This implementation blocks until the user acknowledges that they've completed
+# the authorization at smugmug.com
+def userAuthorizeAtSmugmug(url):
+    get_input("Authorize app at %s\n\nPress Enter when complete.\n" % (url))
+
+# Request an "access token" based on the given request token.  The request token
+# should be authorized at smugmug.com.
+#
+# Return the "access token" that encodes the user's identity and the secrets
+# that authorize this app to access that user's smugmug account.
+def smugmugOauthGetAccessToken(requestToken):
+    # Use the request token to log in (which should be authorized now)
+    smugmug = SmugMug(api_key=API_KEY, oauth_secret=OAUTH_SECRET,
+                      oauth_token=requestToken['Token']['id'],
+                      oauth_token_secret=requestToken['Token']['Secret'],
+                      app_name=APP_NAME)
+ 
+    # The request token is good for 1 operation: to get an access token.
+    response = smugmug.auth_getRequestToken()
+
+    # The access token should be good until the user explicitly
+    # disables it at smugmug.com in their settings panel.
+    return response['Auth'];
+
+
+# Log into smugmug.com with an authorized accessToken.  The accessToken includes
+# the user's identity and, effectively, a password to get this application into
+# the account.
+def smugmugOauthUseAccessToken(accessToken):
+    # Use the access token to log in
+    smugmug = SmugMug(api_key=API_KEY, oauth_secret=OAUTH_SECRET,
+                      oauth_token=accessToke['Token']['id'],
+                      oauth_token_secret=accessToken['Token']['Secret'],
+                      app_name=APP_NAME)
+    return smugmug;
+
+###
+### Main
+###
+
+# Step 1: get request token and authorization URL:
+(url, requestToken) = smugmugOauthRequestToken()
+
+# Step 2: "visit" the authorization URL:
+userAuthorizeAtSmugmug(url)
+
+# Step 3: Upgrade the authorized request token into an access token
+accessToken = smugmugOauthGetAccessToken(requestToken)
+
+# Step 3.5: You should save off the accessToken so you can resume at
+# the following step from now on.  There is no need to jump through
+# the request token and authorization URL more than once.
+
+# Step 4 (and step 1 in the future): log in with the (saved) access
+# token to get an authorized connection to smugmug.com:
+
+smugmug = smugmugOauthUseAccessToken(accessToken)
+
+albums = smugmug.albums_get(NickName=accessToken['User']['NickName'])
 for album in albums["Albums"]:
     print("%s, %s" % (album["id"], album["Title"]))

--- a/smugpy/__init__.py
+++ b/smugpy/__init__.py
@@ -284,13 +284,6 @@ class SmugMug(object):
 
         return urlopen(req).read()
 
-    def fetch_image(self, url, header={}):
-        """Return open file-like handle (from urllib.urlopen) to given image"""
-        header.update({"User-Agent": self.application})
-        req = urlrequest.Request(url, None, header)
-        req.get_method = lambda: "GET"
-        return urlopen(req)
-
     def check_version(self, min=None, max=None):
         """Checks API version
 


### PR DESCRIPTION
Expand example-oauth.py to include all the steps that are required in 
a real client application.  Add a lot of comments.  This was surprisingly
painful to work out from all the bad documentation at Smugmug and oauth.
Hopefully it will be clearer now to others.

Add fetch_image method on Smugmug to GET image data.

Minor improvements to error messages and doc on the Smugmug class.
